### PR TITLE
Feat: support --version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,12 @@ GIT_COMMIT ?= $(shell git rev-parse HEAD 2>/dev/null || echo "unknown")
 GIT_TREE_STATE ?= $(shell if git diff --quiet 2>/dev/null; then echo "clean"; else echo "dirty"; fi)
 BUILD_DATE ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 
-# Go build flags (version info disabled until internal/version package is created)
-LDFLAGS =
+# Go build flags with version injection
+LDFLAGS = -ldflags "\
+	-X github.com/Azure/azure-api-mcp/internal/version.GitVersion=$(VERSION) \
+	-X github.com/Azure/azure-api-mcp/internal/version.GitCommit=$(GIT_COMMIT) \
+	-X github.com/Azure/azure-api-mcp/internal/version.GitTreeState=$(GIT_TREE_STATE) \
+	-X github.com/Azure/azure-api-mcp/internal/version.BuildMetadata=$(BUILD_DATE)"
 
 # Build options
 BUILD_FLAGS = -trimpath

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Azure/azure-api-mcp/internal/config"
 	mcpserver "github.com/Azure/azure-api-mcp/internal/server"
+	"github.com/Azure/azure-api-mcp/internal/version"
 	"github.com/Azure/azure-api-mcp/pkg/azcli"
 	"github.com/mark3labs/mcp-go/server"
 )
@@ -71,14 +72,14 @@ func main() {
 
 	mcpServer := server.NewMCPServer(
 		"Azure API MCP",
-		"1.0.0",
+		version.GetVersion(),
 	)
 
 	callAzTool := azcli.RegisterCallAzTool(cfg.ReadOnlyMode, cfg.DefaultSubscription)
 	callAzHandler := mcpserver.CallAzHandler(client)
 	mcpServer.AddTool(callAzTool, callAzHandler)
 
-	log.Printf("Starting Azure API MCP server (version 1.0.0)")
+	log.Printf("Starting Azure API MCP server (version %s)", version.GetVersion())
 	if err := runServer(mcpServer, cfg); err != nil {
 		log.Fatalf("Server error: %v", err)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/Azure/azure-api-mcp/internal/version"
 	flag "github.com/spf13/pflag"
 )
 
@@ -69,7 +70,13 @@ func (c *Config) ParseFlags() error {
 	}
 
 	if *showVersion {
-		fmt.Printf("Azure API MCP Server version 1.0.0\n")
+		fmt.Printf("Azure API MCP Server\n")
+		fmt.Printf("Version: %s\n", version.GetVersion())
+		versionInfo := version.GetVersionInfo()
+		fmt.Printf("Git Commit: %s\n", versionInfo["gitCommit"])
+		fmt.Printf("Git Tree State: %s\n", versionInfo["gitTreeState"])
+		fmt.Printf("Go Version: %s\n", versionInfo["goVersion"])
+		fmt.Printf("Platform: %s\n", versionInfo["platform"])
 		os.Exit(0)
 	}
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,33 @@
+package version
+
+import (
+	"fmt"
+	"runtime"
+)
+
+var (
+	GitVersion    = "dev"
+	BuildMetadata = ""
+	GitCommit     = ""
+	GitTreeState  = ""
+)
+
+func GetVersion() string {
+	var version string
+	if BuildMetadata != "" {
+		version = fmt.Sprintf("%s+%s", GitVersion, BuildMetadata)
+	} else {
+		version = GitVersion
+	}
+	return version
+}
+
+func GetVersionInfo() map[string]string {
+	return map[string]string{
+		"version":      GetVersion(),
+		"gitCommit":    GitCommit,
+		"gitTreeState": GitTreeState,
+		"goVersion":    runtime.Version(),
+		"platform":     fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+	}
+}


### PR DESCRIPTION
This pull request introduces a new internal versioning system for the project, allowing build-time injection of version, commit, and build metadata into the binary. It replaces hardcoded version strings with dynamically generated version information and provides a new utility for retrieving detailed version info at runtime.

Versioning and build metadata injection:

* Added a new `internal/version/version.go` package that defines version variables (`GitVersion`, `GitCommit`, `GitTreeState`, `BuildMetadata`) and exposes `GetVersion()` and `GetVersionInfo()` functions for retrieving version and build details.
* Updated the `Makefile` to inject versioning information into the binary at build time using Go linker flags, populating the variables in the new `version` package.

Refactoring to use the new versioning system:

* Replaced hardcoded version strings in `cmd/server/main.go` and `internal/config/config.go` with calls to `version.GetVersion()` and `version.GetVersionInfo()`, ensuring that the displayed version reflects the actual build metadata. [[1]](diffhunk://#diff-53cd25fc908d5e63cc8675afbd4ff0910572a985a7cfec27f4460eb674f3b98eL74-R82) [[2]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdL72-R79)
* Updated imports in `cmd/server/main.go` and `internal/config/config.go` to include the new `version` package. [[1]](diffhunk://#diff-53cd25fc908d5e63cc8675afbd4ff0910572a985a7cfec27f4460eb674f3b98eR12) [[2]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR8)