### PR TITLE
Feat: add helm chart for mcp deployment on k8s

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@ coverage.html
 # Build artifacts
 /bin/
 /dist/
-azure-api-mcp
+/azure-api-mcp
 
 # IDE
 .vscode/

--- a/charts/azure-api-mcp/Chart.yaml
+++ b/charts/azure-api-mcp/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: azure-api-mcp
+description: A Helm chart for deploying Azure API MCP server on Kubernetes with Workload Identity support
+type: application
+version: 0.1.0
+appVersion: "1.0.0"
+keywords:
+  - azure
+  - mcp
+  - model-context-protocol
+  - azure-cli
+  - workload-identity
+maintainers:
+  - name: Azure API MCP Team
+home: https://github.com/Azure/azure-api-mcp
+sources:
+  - https://github.com/Azure/azure-api-mcp

--- a/charts/azure-api-mcp/README.md
+++ b/charts/azure-api-mcp/README.md
@@ -1,0 +1,519 @@
+# Azure API MCP Helm Chart
+
+A Helm chart for deploying Azure API MCP server on Kubernetes with Azure Workload Identity support.
+
+## Overview
+
+This Helm chart deploys the Azure API MCP server on a Kubernetes cluster, providing a secure gateway for LLM agents to interact with Azure resources through the Azure CLI. The chart is optimized for Azure Kubernetes Service (AKS) with Workload Identity for passwordless authentication.
+
+**Default Configuration:**
+- **Transport**: `streamable-http` (HTTP-based MCP protocol)
+- **Read-Only Mode**: `false` (write operations allowed)
+- **Authentication**: `workload-identity` (requires Azure setup before installation)
+- **Replicas**: `2` (for high availability)
+- **Port**: `8000`
+
+## Prerequisites
+
+- Kubernetes cluster (AKS recommended)
+- Helm 3.x
+- Azure CLI installed and authenticated
+- AKS cluster with OIDC Issuer enabled (for Workload Identity)
+- Permissions to create Azure Managed Identities and role assignments
+
+## Deployment Guide
+
+Follow these steps in order to deploy Azure API MCP:
+
+### Step 1: Enable OIDC on AKS
+
+```bash
+export RESOURCE_GROUP="<your-resource-group>"
+export AKS_CLUSTER_NAME="<your-aks-cluster>"
+
+# Enable OIDC Issuer and Workload Identity
+az aks update \
+  --resource-group $RESOURCE_GROUP \
+  --name $AKS_CLUSTER_NAME \
+  --enable-oidc-issuer \
+  --enable-workload-identity
+
+# Get OIDC Issuer URL
+export AKS_OIDC_ISSUER=$(az aks show \
+  --resource-group $RESOURCE_GROUP \
+  --name $AKS_CLUSTER_NAME \
+  --query "oidcIssuerProfile.issuerUrl" \
+  --output tsv)
+
+echo "OIDC Issuer: $AKS_OIDC_ISSUER"
+```
+
+### Step 2: Create Azure Managed Identity
+
+```bash
+export IDENTITY_NAME="azure-api-mcp-identity"
+export LOCATION="<your-location>"
+
+# Create Managed Identity
+az identity create \
+  --resource-group $RESOURCE_GROUP \
+  --name $IDENTITY_NAME \
+  --location $LOCATION
+
+# Get Identity Client ID and Principal ID
+export IDENTITY_CLIENT_ID=$(az identity show \
+  --resource-group $RESOURCE_GROUP \
+  --name $IDENTITY_NAME \
+  --query "clientId" \
+  --output tsv)
+
+export IDENTITY_PRINCIPAL_ID=$(az identity show \
+  --resource-group $RESOURCE_GROUP \
+  --name $IDENTITY_NAME \
+  --query "principalId" \
+  --output tsv)
+
+echo "Identity Client ID: $IDENTITY_CLIENT_ID"
+echo "Identity Principal ID: $IDENTITY_PRINCIPAL_ID"
+```
+
+### Step 3: Configure Azure RBAC Permissions
+
+The Azure Managed Identity needs appropriate RBAC roles to access Azure resources. See [Azure RBAC Configuration](#azure-rbac-configuration) section below for detailed permission options.
+
+Quick example (Reader role):
+
+```bash
+export SUBSCRIPTION_ID=$(az account show --query id --output tsv)
+
+az role assignment create \
+  --role "Reader" \
+  --assignee-object-id $IDENTITY_PRINCIPAL_ID \
+  --assignee-principal-type ServicePrincipal \
+  --scope "/subscriptions/$SUBSCRIPTION_ID"
+```
+
+### Step 4: Create Federated Identity Credential
+
+Link the Kubernetes ServiceAccount to the Azure Managed Identity:
+
+```bash
+export SERVICE_ACCOUNT_NAMESPACE="default"
+export SERVICE_ACCOUNT_NAME="azure-mcp-azure-api-mcp"  # Format: <release-name>-<chart-name>
+
+# Create federated credential
+az identity federated-credential create \
+  --name "azure-api-mcp-federated-credential" \
+  --identity-name $IDENTITY_NAME \
+  --resource-group $RESOURCE_GROUP \
+  --issuer $AKS_OIDC_ISSUER \
+  --subject "system:serviceaccount:${SERVICE_ACCOUNT_NAMESPACE}:${SERVICE_ACCOUNT_NAME}" \
+  --audience api://AzureADTokenExchange
+```
+
+**Note**: The ServiceAccount name follows Helm's naming convention: `<release-name>-<chart-name>`. Adjust if using custom release name or `fullnameOverride`.
+
+**Important**: You must create the federated credential BEFORE installing the Helm chart, otherwise authentication will fail.
+
+### Step 5: Install Helm Chart
+
+```bash
+export TENANT_ID=$(az account show --query tenantId --output tsv)
+
+helm install azure-mcp ./charts/azure-api-mcp \
+  --set auth.azure.tenantId=$TENANT_ID \
+  --set auth.azure.clientId=$IDENTITY_CLIENT_ID \
+  --set auth.azure.subscriptionId=$SUBSCRIPTION_ID
+```
+
+### Step 6: Verify Deployment
+
+```bash
+# Check pod status
+kubectl get pods -l app.kubernetes.io/name=azure-api-mcp
+
+# Check logs
+kubectl logs -l app.kubernetes.io/name=azure-api-mcp --tail=50
+
+# Verify authentication
+kubectl exec -it $(kubectl get pod -l app.kubernetes.io/name=azure-api-mcp -o jsonpath='{.items[0].metadata.name}') -- az account show
+```
+
+## Azure RBAC Configuration
+
+The Azure Managed Identity needs appropriate RBAC roles to access Azure resources. Configure based on your requirements:
+
+### Granting Permissions
+
+Example: Grant Reader role at subscription level for read-only access:
+
+```bash
+export SUBSCRIPTION_ID=$(az account show --query id --output tsv)
+
+az role assignment create \
+  --role "Reader" \
+  --assignee-object-id $IDENTITY_PRINCIPAL_ID \
+  --assignee-principal-type ServicePrincipal \
+  --scope "/subscriptions/$SUBSCRIPTION_ID"
+```
+
+For write operations (when `security.readonly=false`), use `Contributor` role or create a custom role with specific permissions.
+
+For resource group-scoped access, change the scope:
+```bash
+--scope "/subscriptions/$SUBSCRIPTION_ID/resourceGroups/<resource-group-name>"
+```
+
+### Best Practices
+
+- Start with minimal permissions (Reader role)
+- Prefer resource group-level scope over subscription-level
+- Use custom roles for fine-grained control
+- Enable security policy with `--enable-security-policy`
+- Regularly audit role assignments
+
+## Configuration Examples
+
+Once you have completed the deployment steps above, you can customize your installation:
+
+### Enable Read-Only Mode
+
+```bash
+helm upgrade azure-mcp ./charts/azure-api-mcp \
+  --reuse-values \
+  --set security.readonly=true
+```
+
+### Enable Security Policy
+
+```bash
+helm upgrade azure-mcp ./charts/azure-api-mcp \
+  --reuse-values \
+  --set security.enableSecurityPolicy=true
+```
+
+### Change Image
+
+```bash
+helm upgrade azure-mcp ./charts/azure-api-mcp \
+  --reuse-values \
+  --set image.repository=myregistry.azurecr.io/azure-api-mcp \
+  --set image.tag=v1.0.0
+```
+
+### Scale Replicas
+
+```bash
+helm upgrade azure-mcp ./charts/azure-api-mcp \
+  --reuse-values \
+  --set replicaCount=3
+```
+
+## Configuration Reference
+
+### Global Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `replicaCount` | Number of replicas | `2` |
+| `nameOverride` | Override chart name | `""` |
+| `fullnameOverride` | Override full name | `""` |
+
+### Image Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `image.repository` | Container image repository | `ghcr.io/azure/azure-api-mcp` |
+| `image.pullPolicy` | Image pull policy | `Always` |
+| `image.tag` | Image tag (defaults to chart appVersion) | `"latest"` |
+| `imagePullSecrets` | Image pull secrets | `[]` |
+
+### Transport Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `transport` | Transport mechanism (`stdio`, `sse`, `streamable-http`) | `streamable-http` |
+| `port` | Server port | `8000` |
+
+### Authentication Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `auth.method` | Auth method (`workload-identity`, `managed-identity`, `service-principal`, `auto`) | `workload-identity` |
+| `auth.skipSetup` | Skip automatic auth setup | `false` |
+| `auth.azure.tenantId` | Azure Tenant ID | `""` |
+| `auth.azure.clientId` | Azure Client ID | `""` |
+| `auth.azure.subscriptionId` | Azure Subscription ID | `""` |
+
+### Security Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `security.readonly` | Enable read-only mode | `false` |
+| `security.enableSecurityPolicy` | Enable security policy enforcement | `false` |
+| `security.timeout` | Command timeout in seconds | `120` |
+| `security.customSecurityPolicyYaml` | Custom security policy YAML content | `""` |
+| `security.customReadonlyPatternsYaml` | Custom readonly patterns YAML content | `""` |
+
+### ServiceAccount Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `serviceAccount.create` | Create ServiceAccount | `true` |
+| `serviceAccount.annotations` | ServiceAccount annotations | `{}` |
+| `serviceAccount.name` | ServiceAccount name (generated if empty) | `""` |
+
+### Workload Identity Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `workloadIdentity.enabled` | Enable Azure Workload Identity | `true` |
+
+### Service Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `service.type` | Service type | `ClusterIP` |
+| `service.port` | Service port | `8000` |
+| `service.targetPort` | Target port | `8000` |
+| `service.annotations` | Service annotations | `{}` |
+
+### Resource Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `resources.limits.cpu` | CPU limit | `500m` |
+| `resources.limits.memory` | Memory limit | `512Mi` |
+| `resources.requests.cpu` | CPU request | `100m` |
+| `resources.requests.memory` | Memory request | `128Mi` |
+
+### Health Check Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `livenessProbe` | Liveness probe configuration | See `values.yaml` |
+| `readinessProbe` | Readiness probe configuration | See `values.yaml` |
+
+### Other Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `nodeSelector` | Node selector | `{}` |
+| `tolerations` | Tolerations | `[]` |
+| `affinity` | Affinity rules | `{}` |
+| `podAnnotations` | Pod annotations | `{}` |
+| `podSecurityContext` | Pod security context | `{}` |
+| `securityContext` | Container security context | `{}` |
+
+## Advanced Configuration
+
+### Custom Security Policy
+
+Create a custom security policy to block specific operations:
+
+```yaml
+# custom-values.yaml
+security:
+  enableSecurityPolicy: true
+  customSecurityPolicyYaml: |
+    deny_patterns:
+      - pattern: "az.*delete.*"
+        reason: "Delete operations are not allowed"
+      - pattern: "az.*logout.*"
+        reason: "Logout not permitted"
+```
+
+Install with custom values:
+
+```bash
+helm install azure-mcp ./charts/azure-api-mcp -f custom-values.yaml
+```
+
+### Custom Readonly Patterns
+
+Override the default readonly patterns:
+
+```yaml
+# custom-values.yaml
+security:
+  readonly: true
+  customReadonlyPatternsYaml: |
+    allow_patterns:
+      - "^az account show"
+      - "^az account list"
+      - "^az vm list"
+      - "^az vm show"
+```
+
+### Multiple Resource Groups
+
+Deploy separate instances for different resource groups:
+
+```bash
+# Instance for production resources
+helm install azure-mcp-prod ./charts/azure-api-mcp \
+  --namespace prod \
+  --create-namespace \
+  --set auth.azure.clientId=$PROD_CLIENT_ID
+
+# Instance for development resources
+helm install azure-mcp-dev ./charts/azure-api-mcp \
+  --namespace dev \
+  --create-namespace \
+  --set auth.azure.clientId=$DEV_CLIENT_ID
+```
+
+## Accessing the Service
+
+### Port Forward (Development)
+
+```bash
+kubectl port-forward svc/azure-mcp-azure-api-mcp 8000:8000
+
+# Test health endpoint
+curl http://localhost:8000/health
+
+# Test MCP endpoint (requires session initialization)
+curl -X POST http://localhost:8000/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0.0"}}}'
+```
+
+### Using with GitHub Copilot
+
+Configure `.vscode/mcp.json` in your workspace:
+
+```json
+{
+  "servers": {
+    "azure-api-mcp": {
+      "url": "http://localhost:8000/mcp",
+      "type": "http"
+    }
+  }
+}
+```
+
+Then port-forward and use Copilot to interact with Azure resources.
+
+## Troubleshooting
+
+### Pod Not Starting
+
+Check pod events and logs:
+
+```bash
+kubectl describe pod -l app.kubernetes.io/name=azure-api-mcp
+kubectl logs -l app.kubernetes.io/name=azure-api-mcp --tail=100
+```
+
+Common issues:
+- **Image pull errors**: Verify image repository and credentials
+- **CrashLoopBackOff**: Check authentication configuration
+
+### Authentication Failures
+
+Verify ServiceAccount configuration:
+
+```bash
+kubectl get serviceaccount azure-mcp-azure-api-mcp -o yaml
+```
+
+Check annotations:
+```yaml
+metadata:
+  annotations:
+    azure.workload.identity/client-id: "<client-id>"
+```
+
+Verify federated credential:
+
+```bash
+az identity federated-credential list \
+  --identity-name $IDENTITY_NAME \
+  --resource-group $RESOURCE_GROUP \
+  --output table
+```
+
+### RBAC Permission Errors
+
+Test permissions inside the pod:
+
+```bash
+kubectl exec -it $(kubectl get pod -l app.kubernetes.io/name=azure-api-mcp -o jsonpath='{.items[0].metadata.name}') -- az vm list
+
+# If permission denied, check role assignments
+az role assignment list --assignee $IDENTITY_PRINCIPAL_ID --all
+```
+
+### Token Projection Issues
+
+Verify token is mounted:
+
+```bash
+kubectl exec -it $(kubectl get pod -l app.kubernetes.io/name=azure-api-mcp -o jsonpath='{.items[0].metadata.name}') -- ls -la /var/run/secrets/azure/tokens/
+```
+
+Check OIDC Issuer configuration:
+
+```bash
+az aks show \
+  --resource-group $RESOURCE_GROUP \
+  --name $AKS_CLUSTER_NAME \
+  --query "oidcIssuerProfile"
+```
+
+## Upgrading
+
+```bash
+# Upgrade with new values
+helm upgrade azure-mcp ./charts/azure-api-mcp \
+  --set image.tag=v1.1.0
+
+# View release history
+helm history azure-mcp
+
+# Rollback if needed
+helm rollback azure-mcp 1
+```
+
+## Uninstalling
+
+```bash
+# Remove Helm release
+helm uninstall azure-mcp
+
+# Clean up Azure resources
+az identity federated-credential delete \
+  --name "azure-api-mcp-federated-credential" \
+  --identity-name $IDENTITY_NAME \
+  --resource-group $RESOURCE_GROUP
+
+az identity delete \
+  --resource-group $RESOURCE_GROUP \
+  --name $IDENTITY_NAME
+```
+
+## Security Best Practices
+
+1. **Use Workload Identity**: Avoid storing credentials in Kubernetes Secrets
+2. **Enable Read-Only Mode**: Set `security.readonly=true` for monitoring use cases
+3. **Enable Security Policy**: Set `security.enableSecurityPolicy=true` to block dangerous operations
+4. **Scope RBAC Permissions**: Grant minimal Azure RBAC permissions required
+5. **Use Resource Group Scoping**: Assign permissions at resource group level instead of subscription
+6. **Network Policies**: Deploy NetworkPolicies to restrict pod network access
+7. **Regular Audits**: Review Azure RBAC assignments and Kubernetes configurations periodically
+
+## References
+
+- [Azure Workload Identity Documentation](https://azure.github.io/azure-workload-identity/)
+- [Azure RBAC Documentation](https://docs.microsoft.com/en-us/azure/role-based-access-control/)
+- [AKS OIDC Issuer](https://docs.microsoft.com/en-us/azure/aks/use-oidc-issuer)
+- [Project Repository](https://github.com/Azure/azure-api-mcp)
+- [Model Context Protocol Specification](https://modelcontextprotocol.io/)
+
+## Support
+
+For issues and questions:
+- GitHub Issues: https://github.com/Azure/azure-api-mcp/issues
+- Documentation: https://github.com/Azure/azure-api-mcp/tree/main/docs

--- a/charts/azure-api-mcp/templates/NOTES.txt
+++ b/charts/azure-api-mcp/templates/NOTES.txt
@@ -1,0 +1,79 @@
+🎉 Azure API MCP has been successfully deployed!
+
+Release Name: {{ .Release.Name }}
+Namespace: {{ .Release.Namespace }}
+
+{{- if .Values.workloadIdentity.enabled }}
+{{- if or (not .Values.auth.azure.clientId) (not .Values.auth.azure.tenantId) }}
+
+⚠️  CRITICAL: Required authentication parameters are missing!
+   
+   Workload Identity is enabled but the following required parameters are not set:
+   {{- if not .Values.auth.azure.clientId }}
+   - auth.azure.clientId (REQUIRED)
+   {{- end }}
+   {{- if not .Values.auth.azure.tenantId }}
+   - auth.azure.tenantId (REQUIRED)
+   {{- end }}
+
+   Your pods will fail to start with authentication errors!
+
+   Please upgrade with:
+   helm upgrade {{ .Release.Name }} ./charts/azure-api-mcp \
+     --set auth.azure.tenantId=<your-tenant-id> \
+     --set auth.azure.clientId=<your-managed-identity-client-id> \
+     --set auth.azure.subscriptionId=<your-subscription-id>
+
+{{- end }}
+{{- end }}
+
+To verify the deployment:
+
+  kubectl get pods -n {{ .Release.Namespace }} -l app.kubernetes.io/name={{ include "azure-api-mcp.name" . }}
+
+To check the logs:
+
+  kubectl logs -n {{ .Release.Namespace }} -l app.kubernetes.io/name={{ include "azure-api-mcp.name" . }} --tail=50
+
+To access the service:
+
+  {{- if eq .Values.service.type "ClusterIP" }}
+  # Port forward to access locally
+  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "azure-api-mcp.fullname" . }} 8000:{{ .Values.service.port }}
+
+  # Then access:
+  curl http://localhost:8000/health
+  {{- else if eq .Values.service.type "LoadBalancer" }}
+  # Get the external IP
+  kubectl get svc -n {{ .Release.Namespace }} {{ include "azure-api-mcp.fullname" . }}
+  {{- end }}
+
+Configuration:
+  - Transport: {{ .Values.transport }}
+  - Auth Method: {{ .Values.auth.method }}
+  - Read-Only Mode: {{ .Values.security.readonly }}
+  - Security Policy: {{ .Values.security.enableSecurityPolicy }}
+  {{- if .Values.workloadIdentity.enabled }}
+  - Workload Identity: Enabled
+  {{- end }}
+
+{{- if and .Values.workloadIdentity.enabled .Values.auth.azure.clientId .Values.auth.azure.tenantId }}
+
+Next steps for Workload Identity setup (if not done):
+
+1. Create Azure Managed Identity and federated credential:
+
+   export IDENTITY_CLIENT_ID="{{ .Values.auth.azure.clientId }}"
+   export TENANT_ID="{{ .Values.auth.azure.tenantId }}"
+   {{- if .Values.auth.azure.subscriptionId }}
+   export SUBSCRIPTION_ID="{{ .Values.auth.azure.subscriptionId }}"
+   {{- end }}
+   
+   See the chart README for detailed RBAC configuration instructions.
+
+2. Verify authentication:
+
+   kubectl exec -it -n {{ .Release.Namespace }} $(kubectl get pod -n {{ .Release.Namespace }} -l app.kubernetes.io/name={{ include "azure-api-mcp.name" . }} -o jsonpath='{.items[0].metadata.name}') -- az account show
+{{- end }}
+
+For more information, visit: https://github.com/Azure/azure-api-mcp

--- a/charts/azure-api-mcp/templates/_helpers.tpl
+++ b/charts/azure-api-mcp/templates/_helpers.tpl
@@ -1,0 +1,60 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "azure-api-mcp.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "azure-api-mcp.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "azure-api-mcp.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "azure-api-mcp.labels" -}}
+helm.sh/chart: {{ include "azure-api-mcp.chart" . }}
+{{ include "azure-api-mcp.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "azure-api-mcp.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "azure-api-mcp.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "azure-api-mcp.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "azure-api-mcp.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/azure-api-mcp/templates/configmap.yaml
+++ b/charts/azure-api-mcp/templates/configmap.yaml
@@ -1,0 +1,18 @@
+{{- if or .Values.security.customSecurityPolicyYaml .Values.security.customReadonlyPatternsYaml -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "azure-api-mcp.fullname" . }}-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "azure-api-mcp.labels" . | nindent 4 }}
+data:
+  {{- if .Values.security.customSecurityPolicyYaml }}
+  security-policy.yaml: |
+{{ .Values.security.customSecurityPolicyYaml | indent 4 }}
+  {{- end }}
+  {{- if .Values.security.customReadonlyPatternsYaml }}
+  readonly-patterns.yaml: |
+{{ .Values.security.customReadonlyPatternsYaml | indent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/azure-api-mcp/templates/deployment.yaml
+++ b/charts/azure-api-mcp/templates/deployment.yaml
@@ -1,0 +1,139 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "azure-api-mcp.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "azure-api-mcp.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "azure-api-mcp.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "azure-api-mcp.selectorLabels" . | nindent 8 }}
+        {{- if .Values.workloadIdentity.enabled }}
+        azure.workload.identity/use: "true"
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "azure-api-mcp.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+      - name: {{ .Chart.Name }}
+        {{- with .Values.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports:
+        - name: http
+          containerPort: {{ .Values.port }}
+          protocol: TCP
+        env:
+        {{- if .Values.auth.azure.tenantId }}
+        - name: AZURE_TENANT_ID
+          value: {{ .Values.auth.azure.tenantId | quote }}
+        {{- end }}
+        {{- if .Values.auth.azure.clientId }}
+        - name: AZURE_CLIENT_ID
+          value: {{ .Values.auth.azure.clientId | quote }}
+        {{- end }}
+        {{- if .Values.workloadIdentity.enabled }}
+        - name: AZURE_FEDERATED_TOKEN_FILE
+          value: "/var/run/secrets/azure/tokens/azure-identity-token"
+        {{- end }}
+        {{- if .Values.auth.azure.subscriptionId }}
+        - name: AZURE_SUBSCRIPTION_ID
+          value: {{ .Values.auth.azure.subscriptionId | quote }}
+        {{- end }}
+        - name: AZ_AUTH_METHOD
+          value: {{ .Values.auth.method | quote }}
+        {{- if .Values.auth.skipSetup }}
+        - name: AZ_API_MCP_SKIP_AUTH_SETUP
+          value: "true"
+        {{- end }}
+        args:
+        - "--transport"
+        - {{ .Values.transport | quote }}
+        - "--host"
+        - "0.0.0.0"
+        - "--port"
+        - {{ .Values.port | quote }}
+        - "--readonly={{ .Values.security.readonly }}"
+        {{- if .Values.security.enableSecurityPolicy }}
+        - "--enable-security-policy"
+        {{- end }}
+        {{- if .Values.security.customSecurityPolicyYaml }}
+        - "--security-policy-file"
+        - "/etc/azure-api-mcp/security-policy.yaml"
+        {{- end }}
+        {{- if .Values.security.customReadonlyPatternsYaml }}
+        - "--readonly-patterns-file"
+        - "/etc/azure-api-mcp/readonly-patterns.yaml"
+        {{- end }}
+        - "--timeout"
+        - {{ .Values.security.timeout | quote }}
+        {{- with .Values.livenessProbe }}
+        livenessProbe:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.readinessProbe }}
+        readinessProbe:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        volumeMounts:
+        {{- if .Values.workloadIdentity.enabled }}
+        - name: azure-identity-token
+          mountPath: /var/run/secrets/azure/tokens
+          readOnly: true
+        {{- end }}
+        {{- if or .Values.security.customSecurityPolicyYaml .Values.security.customReadonlyPatternsYaml }}
+        - name: config
+          mountPath: /etc/azure-api-mcp
+          readOnly: true
+        {{- end }}
+      volumes:
+      {{- if .Values.workloadIdentity.enabled }}
+      - name: azure-identity-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              path: azure-identity-token
+              expirationSeconds: 86400
+              audience: api://AzureADTokenExchange
+      {{- end }}
+      {{- if or .Values.security.customSecurityPolicyYaml .Values.security.customReadonlyPatternsYaml }}
+      - name: config
+        configMap:
+          name: {{ include "azure-api-mcp.fullname" . }}-config
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/azure-api-mcp/templates/service.yaml
+++ b/charts/azure-api-mcp/templates/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "azure-api-mcp.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "azure-api-mcp.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  - name: http
+    port: {{ .Values.service.port }}
+    targetPort: {{ .Values.service.targetPort }}
+    protocol: TCP
+  selector:
+    {{- include "azure-api-mcp.selectorLabels" . | nindent 4 }}

--- a/charts/azure-api-mcp/templates/serviceaccount.yaml
+++ b/charts/azure-api-mcp/templates/serviceaccount.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.serviceAccount.create -}}
+{{- if and .Values.workloadIdentity.enabled (not .Values.auth.azure.clientId) }}
+{{- fail "ERROR: auth.azure.clientId is required when workloadIdentity.enabled=true. Please set --set auth.azure.clientId=<your-client-id>" }}
+{{- end }}
+{{- if and .Values.workloadIdentity.enabled (not .Values.auth.azure.tenantId) }}
+{{- fail "ERROR: auth.azure.tenantId is required when workloadIdentity.enabled=true. Please set --set auth.azure.tenantId=<your-tenant-id>" }}
+{{- end }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "azure-api-mcp.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "azure-api-mcp.labels" . | nindent 4 }}
+    {{- if .Values.workloadIdentity.enabled }}
+    azure.workload.identity/use: "true"
+    {{- end }}
+  annotations:
+    {{- if and .Values.workloadIdentity.enabled .Values.auth.azure.clientId }}
+    azure.workload.identity/client-id: {{ .Values.auth.azure.clientId | quote }}
+    {{- end }}
+    {{- with .Values.serviceAccount.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/charts/azure-api-mcp/values.yaml
+++ b/charts/azure-api-mcp/values.yaml
@@ -1,0 +1,81 @@
+replicaCount: 2
+
+image:
+  repository: ghcr.io/azure/azure-api-mcp
+  pullPolicy: Always
+  tag: "latest"
+
+imagePullSecrets: []
+
+nameOverride: ""
+fullnameOverride: ""
+
+transport: streamable-http
+port: 8000
+
+auth:
+  method: workload-identity
+  skipSetup: false
+  azure:
+    tenantId: ""
+    clientId: ""
+    subscriptionId: ""
+
+security:
+  readonly: false
+  enableSecurityPolicy: false
+  timeout: 120
+  customSecurityPolicyYaml: ""
+  customReadonlyPatternsYaml: ""
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+workloadIdentity:
+  enabled: true
+
+service:
+  type: ClusterIP
+  port: 8000
+  targetPort: 8000
+  annotations: {}
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 512Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+livenessProbe:
+  httpGet:
+    path: /health
+    port: 8000
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /health
+    port: 8000
+  initialDelaySeconds: 10
+  periodSeconds: 5
+  timeoutSeconds: 3
+  failureThreshold: 3
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+podAnnotations: {}
+
+podSecurityContext: {}
+
+securityContext: {}


### PR DESCRIPTION
This pull request introduces a new Helm chart for deploying the Azure API MCP server on Kubernetes, with built-in support for Azure Workload Identity. The chart includes templates for deployment, service, service account, config map, and helper functions, as well as a comprehensive default configuration in `values.yaml`. The chart is designed to support secure deployments, flexible configuration, and integration with Azure authentication and security policies.

**Helm Chart Introduction and Structure**

* Added a new Helm chart definition for Azure API MCP, including metadata, keywords, maintainers, and sources in `Chart.yaml`.
* Created default configuration values in `values.yaml`, covering image details, authentication, security policies, probes, resources, and Kubernetes deployment options.

**Deployment and Service Templates**

* Implemented a Kubernetes deployment template (`deployment.yaml`) supporting Workload Identity, security policy files, custom probes, and resource configuration.
* Added a service template (`service.yaml`) to expose the MCP server with customizable annotations and port mappings.

**Authentication, Identity, and Security**

* Service account template (`serviceaccount.yaml`) enforces required Azure authentication parameters when Workload Identity is enabled, and annotates the service account for Azure integration.
* ConfigMap template (`configmap.yaml`) allows mounting custom security policy and readonly patterns YAML files into the deployment.

**Chart Helpers and User Guidance**

* Provided helper templates (`_helpers.tpl`) for consistent naming, labels, and service account references across chart resources.
* Added a detailed `NOTES.txt` for post-deployment instructions, workload identity setup, and troubleshooting guidance.