### PR TITLE
fix: block credential-bearing commands in readonly mode

### DIFF
--- a/pkg/azcli/validator.go
+++ b/pkg/azcli/validator.go
@@ -164,6 +164,23 @@ func (v *DefaultValidator) checkReadOnly(cmdStr string) error {
 		return NewAzCliError(ErrorTypeCommandDenied, "read-only patterns not loaded", cmdStr)
 	}
 
+	// Hardcoded denylist: credential-bearing commands are never allowed in readonly mode,
+	// regardless of pattern matches. These return or write credential material that can
+	// be used outside of AKS-MCP to bypass the readonly access level entirely.
+	credentialDenyPrefixes := []string{
+		"az account get-access-token",
+		"az aks get-credentials",
+		"az fleet get-credentials",
+		"az ad app credential",
+		"az ad sp credential",
+	}
+	for _, prefix := range credentialDenyPrefixes {
+		if strings.HasPrefix(cmdStr, prefix) {
+			return NewAzCliError(ErrorTypeCommandDenied,
+				"command returns credential material and is not allowed in read-only mode", cmdStr)
+		}
+	}
+
 	for _, pattern := range v.readOnlyPatterns.Patterns {
 		matched, err := regexp.MatchString(pattern, cmdStr)
 		if err != nil {

--- a/pkg/azcli/validator.go
+++ b/pkg/azcli/validator.go
@@ -165,8 +165,7 @@ func (v *DefaultValidator) checkReadOnly(cmdStr string) error {
 	}
 
 	// Hardcoded denylist: credential-bearing commands are never allowed in readonly mode,
-	// regardless of pattern matches. These return or write credential material that can
-	// be used outside of AKS-MCP to bypass the readonly access level entirely.
+	// regardless of pattern matches.
 	credentialDenyPrefixes := []string{
 		"az account get-access-token",
 		"az aks get-credentials",

--- a/pkg/azcli/validator.go
+++ b/pkg/azcli/validator.go
@@ -173,8 +173,9 @@ func (v *DefaultValidator) checkReadOnly(cmdStr string) error {
 		"az ad app credential",
 		"az ad sp credential",
 	}
+	normalizedCmd := strings.Join(strings.Fields(cmdStr), " ")
 	for _, prefix := range credentialDenyPrefixes {
-		if strings.HasPrefix(cmdStr, prefix) {
+		if strings.HasPrefix(normalizedCmd, prefix) {
 			return NewAzCliError(ErrorTypeCommandDenied,
 				"command returns credential material and is not allowed in read-only mode", cmdStr)
 		}

--- a/pkg/azcli/validator_test.go
+++ b/pkg/azcli/validator_test.go
@@ -321,6 +321,40 @@ policy:
 	}
 }
 
+func TestValidator_CheckReadOnly_CredentialBearingCommands(t *testing.T) {
+	patterns, err := LoadReadOnlyPatterns("")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	validator := &DefaultValidator{
+		readOnlyMode:     true,
+		readOnlyPatterns: patterns,
+	}
+
+	credentialCommands := []struct {
+		name  string
+		input string
+	}{
+		{"get-access-token", "az account get-access-token"},
+		{"get-access-token with resource", "az account get-access-token --resource https://management.azure.com/"},
+		{"aks get-credentials", "az aks get-credentials --resource-group rg --name cluster"},
+		{"aks get-credentials with file", "az aks get-credentials --resource-group rg --name cluster --file /tmp/kube"},
+		{"fleet get-credentials", "az fleet get-credentials --resource-group rg --name fleet"},
+		{"ad app credential list", "az ad app credential list --id abc"},
+		{"ad sp credential list", "az ad sp credential list --id xyz"},
+	}
+
+	for _, tt := range credentialCommands {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validator.checkReadOnly(tt.input)
+			if err == nil {
+				t.Errorf("checkReadOnly(%q) expected error (credential-bearing command), got nil", tt.input)
+			}
+		})
+	}
+}
+
 func TestIsAzureHost(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Summary

Block credential-bearing Azure CLI commands (`az account get-access-token`, `az aks get-credentials`, `az fleet get-credentials`, `az ad app credential`, `az ad sp credential`) in readonly mode. These commands are added to a hardcoded denylist evaluated before the allowlist pattern matching in `checkReadOnly()`.

## Test plan

- [ ] `go test ./pkg/azcli/...` passes