### PR TITLE
fix: extend credential-bearing command denylist in read-only mode

### DIFF
--- a/pkg/azcli/validator.go
+++ b/pkg/azcli/validator.go
@@ -186,13 +186,30 @@ func (v *DefaultValidator) checkReadOnly(cmdStr string) error {
 	}
 
 	// Hardcoded denylist: credential-bearing commands are never allowed in readonly mode,
-	// regardless of pattern matches.
+	// regardless of pattern matches. These commands match the broad read-only
+	// regexes (list / show / get-*) but actually return reusable credentials
+	// rather than metadata (keys, secrets, connection strings, kubeconfigs,
+	// access tokens, app settings).
 	credentialDenyPrefixes := []string{
 		"az account get-access-token",
 		"az aks get-credentials",
 		"az fleet get-credentials",
 		"az ad app credential",
 		"az ad sp credential",
+		"az storage account keys list",
+		"az storage account show-connection-string",
+		"az keyvault secret show",
+		"az keyvault secret list",
+		"az keyvault secret download",
+		"az cosmosdb keys list",
+		"az cosmosdb list-connection-strings",
+		"az redis list-keys",
+		"az acr credential show",
+		"az cognitiveservices account keys list",
+		"az servicebus namespace authorization-rule keys list",
+		"az eventhubs namespace authorization-rule keys list",
+		"az webapp config appsettings list",
+		"az functionapp config appsettings list",
 	}
 	normalizedCmd := strings.Join(strings.Fields(cmdStr), " ")
 	for _, prefix := range credentialDenyPrefixes {

--- a/pkg/azcli/validator_test.go
+++ b/pkg/azcli/validator_test.go
@@ -403,6 +403,21 @@ func TestValidator_CheckReadOnly_CredentialBearingCommands(t *testing.T) {
 		{"fleet get-credentials", "az fleet get-credentials --resource-group rg --name fleet"},
 		{"ad app credential list", "az ad app credential list --id abc"},
 		{"ad sp credential list", "az ad sp credential list --id xyz"},
+		{"storage account keys list", "az storage account keys list --account-name mystorage --resource-group rg"},
+		{"storage account show-connection-string", "az storage account show-connection-string --name mystorage --resource-group rg"},
+		{"keyvault secret show", "az keyvault secret show --vault-name myvault --name mysecret"},
+		{"keyvault secret list", "az keyvault secret list --vault-name myvault"},
+		{"keyvault secret download", "az keyvault secret download --vault-name myvault --name mysecret --file /tmp/s"},
+		{"cosmosdb keys list", "az cosmosdb keys list --name mycosmos --resource-group rg"},
+		{"cosmosdb list-connection-strings", "az cosmosdb list-connection-strings --name mycosmos --resource-group rg"},
+		{"redis list-keys", "az redis list-keys --name myredis --resource-group rg"},
+		{"acr credential show", "az acr credential show --name myacr"},
+		{"cognitiveservices account keys list", "az cognitiveservices account keys list --name myopenai --resource-group rg"},
+		{"servicebus authorization-rule keys list", "az servicebus namespace authorization-rule keys list --resource-group rg --namespace-name myns --name RootManageSharedAccessKey"},
+		{"eventhubs authorization-rule keys list", "az eventhubs namespace authorization-rule keys list --resource-group rg --namespace-name myns --name RootManageSharedAccessKey"},
+		{"webapp config appsettings list", "az webapp config appsettings list --name myapp --resource-group rg"},
+		{"functionapp config appsettings list", "az functionapp config appsettings list --name myfunc --resource-group rg"},
+		{"whitespace-bypass attempt", "az  storage  account  keys  list --account-name mystorage --resource-group rg"},
 	}
 
 	for _, tt := range credentialCommands {


### PR DESCRIPTION
## Summary

Several Azure CLI commands match the broad read-only regex patterns
(`list` / `show` / `get-*`) but return reusable credentials rather than
metadata. The existing hardcoded `credentialDenyPrefixes` in `checkReadOnly`
covered authentication tokens and AKS / Fleet / AD credentials, but did not
extend to service-specific credential retrieval.

This PR extends `credentialDenyPrefixes` to cover the remaining
credential-bearing read-only commands so they are rejected regardless of the
read-only allowlist match.

### New entries

- `az storage account keys list`
- `az storage account show-connection-string`
- `az keyvault secret show` / `secret list` / `secret download`
- `az cosmosdb keys list`
- `az cosmosdb list-connection-strings`
- `az redis list-keys`
- `az acr credential show`
- `az cognitiveservices account keys list`
- `az servicebus namespace authorization-rule keys list`
- `az eventhubs namespace authorization-rule keys list`
- `az webapp config appsettings list`
- `az functionapp config appsettings list`

The existing whitespace-normalized prefix-match loop handles the new entries
unchanged. No other code paths or APIs are touched.

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/azcli/...`
- [x] `go test -run TestValidator_CheckReadOnly_CredentialBearingCommands -v ./pkg/azcli/...` — every new prefix has a passing sub-test, plus a whitespace-bypass case
- [x] Existing `TestValidator_CheckReadOnly`, `TestValidator_CheckDenyList`, `TestValidator_ValidateFlagSecurity`, `TestDefaultSecurityPolicy_DeniesMSRCFindings` still pass