### PR TITLE
Make the MCP server stdio-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A secure MCP (Model Context Protocol) server that provides controlled access to 
 ## Features
 
 - **Multi-layer Security Validation**: Basic security checks, configurable security policy, and read-only mode
-- **Flexible Authentication**: Support for workload identity, managed identity, service principal, and existing sessions
+- **Flexible Authentication**: Support for workload identity, managed identity, service principals, and existing Azure CLI sessions
 - **Embedded Configuration**: Config files embedded in binary, no external dependencies required
 - **Local stdio Transport**: starts as a subprocess of your MCP client
 - **Timeout Control**: Configurable command execution timeouts
@@ -131,19 +131,13 @@ AZURE_SUBSCRIPTION_ID=xxx
 
 This MCP server executes Azure CLI commands provided by LLM. While multiple validation layers are implemented, LLM may generate unexpected commands or discover validation bypasses. We strongly recommend:
 
-1. **Deploy with workload identity** - Use Azure RBAC for access control and pod security policies to limit blast radius in case the mcp server pod is compromised.
+1. **Run locally through stdio** - Configure an MCP client to start this binary as a local subprocess. Do not expose it through a network proxy or gateway.
 2. **Use agent frameworks with intervention handlers** - Require explicit user approval before executing commands.
 3. **Apply principle of least privilege** - Grant minimal permissions and enable security controls.
 
-### Recommended Deployment: Workload Identity on AKS
-
-**For production use, we strongly recommend deploying this MCP server on AKS with workload identity authentication.** This decouples agent permissions from user identity and leverages Azure RBAC for enterprise-grade access control.
-
-For deployment guidance, see this reference guide for deploying MCP servers on AKS with workload identity (the steps are similar for azure-api-mcp): [Deploy MCP Server on AKS with Workload Identity](https://blog.aks.azure.com/2025/10/22/deploy-mcp-server-aks-workload-identity)
-
 ### Foundation: Azure RBAC
 
-The most important security feature is **Azure RBAC integration through workload identity**. When using workload identity or managed identity authentication, all agent operations are subject to the Azure identity's RBAC role assignments. This provides enterprise-grade access control at the Azure platform level, complementing the application-level validation policies below.
+The authoritative authorization boundary is Azure RBAC for the identity used by the local Azure CLI process.
 
 Example: An agent with Azure Reader role can only perform read operations regardless of application configuration, while an agent with Contributor role on a specific resource group can only affect resources within that scope.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A secure MCP (Model Context Protocol) server that provides controlled access to 
 - **Multi-layer Security Validation**: Basic security checks, configurable security policy, and read-only mode
 - **Flexible Authentication**: Support for workload identity, managed identity, service principal, and existing sessions
 - **Embedded Configuration**: Config files embedded in binary, no external dependencies required
-- **Multiple Transport Modes**: stdio, SSE, and streamable-http
+- **Local stdio Transport**: starts as a subprocess of your MCP client
 - **Timeout Control**: Configurable command execution timeouts
 - **Structured Error Handling**: Detailed error information and types
 
@@ -36,8 +36,6 @@ go build -o bin/azure-api-mcp ./cmd/server
 # With security policy
 ./bin/azure-api-mcp --enable-security-policy --security-policy-file configs/security-policy.yaml
 
-# SSE transport mode
-./bin/azure-api-mcp --transport sse --host 0.0.0.0 --port 8000
 ```
 
 ## Authentication
@@ -98,9 +96,7 @@ The primary tool for executing Azure CLI commands.
 
 ```bash
 # Transport mode
---transport string          Transport mode: stdio, sse, streamable-http (default "stdio")
---host string              Host to listen on for non-stdio transport (default "127.0.0.1")
---port int                 Port to listen on for non-stdio transport (default 8000)
+--transport string          Transport mode: stdio only (default "stdio")
 
 # Security configuration
 --readonly                 Enable read-only mode (default false)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"os"
 	"time"
 
@@ -103,74 +102,10 @@ func main() {
 }
 
 func runServer(mcpServer *server.MCPServer, cfg *config.Config) error {
-	switch cfg.Transport {
-	case "stdio":
-		logger.Info("Listening for requests on STDIO...")
-		return server.ServeStdio(mcpServer)
-
-	case "sse":
-		addr := fmt.Sprintf("%s:%d", cfg.Host, cfg.Port)
-		baseURL := fmt.Sprintf("http://%s", addr)
-
-		mux := http.NewServeMux()
-		mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{"status":"healthy"}`))
-		})
-
-		customServer := &http.Server{
-			Addr:              addr,
-			Handler:           mux,
-			ReadHeaderTimeout: 10 * time.Second,
-		}
-
-		sseServer := server.NewSSEServer(
-			mcpServer,
-			server.WithBaseURL(baseURL),
-			server.WithHTTPServer(customServer),
-		)
-
-		logger.Infof("SSE server listening on %s", addr)
-		logger.Infof("Base URL: %s", baseURL)
-		logger.Infof("SSE endpoint available at: http://%s/sse", addr)
-		logger.Infof("Message endpoint available at: http://%s/message", addr)
-		logger.Infof("Health check available at: http://%s/health", addr)
-		logger.Info("Connect to /sse for real-time events, send JSON-RPC to /message")
-
-		return sseServer.Start(addr)
-
-	case "streamable-http":
-		addr := fmt.Sprintf("%s:%d", cfg.Host, cfg.Port)
-
-		mux := http.NewServeMux()
-		mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{"status":"healthy"}`))
-		})
-
-		customServer := &http.Server{
-			Addr:              addr,
-			Handler:           mux,
-			ReadHeaderTimeout: 10 * time.Second,
-		}
-
-		streamableServer := server.NewStreamableHTTPServer(
-			mcpServer,
-			server.WithStreamableHTTPServer(customServer),
-		)
-
-		mux.Handle("/mcp", streamableServer)
-
-		logger.Infof("Streamable HTTP server listening on %s", addr)
-		logger.Infof("MCP endpoint available at: http://%s/mcp", addr)
-		logger.Infof("Health check available at: http://%s/health", addr)
-		logger.Info("Send POST requests to /mcp to initialize session and obtain Mcp-Session-Id")
-
-		return customServer.ListenAndServe()
-
-	default:
-		return fmt.Errorf("invalid transport type: %s (must be 'stdio', 'sse', or 'streamable-http')", cfg.Transport)
+	if cfg.Transport != "stdio" {
+		return fmt.Errorf("unsupported transport %q: only stdio is supported", cfg.Transport)
 	}
+
+	logger.Info("Listening for requests on STDIO...")
+	return server.ServeStdio(mcpServer)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,8 +16,6 @@ type Config struct {
 	SecurityPolicyFile   string
 	ReadOnlyPatternsFile string
 	Transport            string
-	Host                 string
-	Port                 int
 	LogLevel             string
 
 	SkipAuthSetup       bool
@@ -37,8 +35,6 @@ func NewConfig() *Config {
 		SecurityPolicyFile:   "",
 		ReadOnlyPatternsFile: "",
 		Transport:            "stdio",
-		Host:                 "127.0.0.1",
-		Port:                 8000,
 		LogLevel:             "info",
 
 		SkipAuthSetup: false,
@@ -52,9 +48,7 @@ func (c *Config) ParseFlags() error {
 	flag.IntVar(&c.Timeout, "timeout", c.Timeout, "Timeout for command execution in seconds")
 	flag.StringVar(&c.SecurityPolicyFile, "security-policy-file", c.SecurityPolicyFile, "Path to security policy YAML file")
 	flag.StringVar(&c.ReadOnlyPatternsFile, "readonly-patterns-file", c.ReadOnlyPatternsFile, "Path to read-only patterns YAML file")
-	flag.StringVar(&c.Transport, "transport", c.Transport, "Transport mechanism (stdio, sse, streamable-http)")
-	flag.StringVar(&c.Host, "host", c.Host, "Host to listen on (for non-stdio transport)")
-	flag.IntVar(&c.Port, "port", c.Port, "Port to listen on (for non-stdio transport)")
+	flag.StringVar(&c.Transport, "transport", c.Transport, "Transport mechanism (stdio only)")
 	flag.StringVar(&c.LogLevel, "log-level", c.LogLevel, "Log level (debug, info, warn, error)")
 	flag.StringVar(&c.AuthMethod, "auth-method", c.AuthMethod, "Authentication method (auto, workload-identity, managed-identity, service-principal)")
 
@@ -122,14 +116,8 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("timeout must be greater than 0")
 	}
 
-	validTransports := map[string]bool{
-		"stdio":           true,
-		"sse":             true,
-		"streamable-http": true,
-	}
-
-	if !validTransports[c.Transport] {
-		return fmt.Errorf("invalid transport: %s (must be stdio, sse, or streamable-http)", c.Transport)
+	if c.Transport != "stdio" {
+		return fmt.Errorf("unsupported transport %q: only stdio is supported", c.Transport)
 	}
 
 	return nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,26 @@
+package config
+
+import "testing"
+
+func TestValidateTransport(t *testing.T) {
+	tests := []struct {
+		name      string
+		transport string
+		wantErr   bool
+	}{
+		{name: "stdio", transport: "stdio"},
+		{name: "SSE", transport: "sse", wantErr: true},
+		{name: "streamable HTTP", transport: "streamable-http", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := NewConfig()
+			cfg.Transport = tt.transport
+			err := cfg.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Validate() error = %v, wantErr %t", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Remove SSE and streamable HTTP transports and make stdio the only supported runtime transport.

Part of #31.

## Breaking change

Network endpoints and transport-specific configuration are no longer supported. Invocations selecting `sse` or `streamable-http` now fail explicitly.

## Validation

- Ran `go test ./...`.
- Confirmed that production runtime code no longer creates an HTTP listener.